### PR TITLE
Add sourceOnly option

### DIFF
--- a/addon/components/drag-sort-item.js
+++ b/addon/components/drag-sort-item.js
@@ -32,6 +32,7 @@ export default Component.extend({
   handle          : null,
   isHorizontal    : false,
   isRtl           : false,
+  sourceOnly      : false,
 
   dragEndAction                  : undefined,
   determineForeignPositionAction : undefined,
@@ -116,18 +117,20 @@ export default Component.extend({
     return index === count - 1
   }),
 
-  shouldShowPlaceholderBefore : computed('isDraggingOver', 'isDraggingUp', function () {
+  shouldShowPlaceholderBefore : computed('isDraggingOver', 'isDraggingUp', 'sourceOnly', function () {
     const isDraggingOver = this.get('isDraggingOver')
     const isDraggingUp   = this.get('isDraggingUp')
+    const sourceOnly     = this.get('sourceOnly')
 
-    return isDraggingOver && isDraggingUp
+    return !sourceOnly && isDraggingOver && isDraggingUp
   }),
 
-  shouldShowPlaceholderAfter : computed('isDraggingOver', 'isDraggingUp', function () {
+  shouldShowPlaceholderAfter : computed('isDraggingOver', 'isDraggingUp', 'sourceOnly', function () {
     const isDraggingOver = this.get('isDraggingOver')
     const isDraggingUp   = this.get('isDraggingUp')
+    const sourceOnly     = this.get('sourceOnly')
 
-    return isDraggingOver && !isDraggingUp
+    return !sourceOnly && isDraggingOver && !isDraggingUp
   }),
 
 
@@ -229,6 +232,13 @@ export default Component.extend({
   },
 
   draggingOver (event) {
+    const sourceOnly          = this.get('sourceOnly')
+
+    if (sourceOnly) { 
+      event.preventDefault()
+      return
+    }
+
     const group               = this.get('group')
     const index               = this.get('index')
     const items               = this.get('items')

--- a/addon/templates/components/drag-sort-list.hbs
+++ b/addon/templates/components/drag-sort-list.hbs
@@ -13,6 +13,7 @@
     draggingEnabled                = draggingEnabled
     dragEndAction                  = dragEndAction
     determineForeignPositionAction = determineForeignPositionAction
+    sourceOnly                     = sourceOnly
   }}
     {{yield item index}}
   {{/drag-sort-item}}


### PR DESCRIPTION
This adds support for a list to be source only and not allow dropping items into it, rearranging items etc. It's a bit rough, and I am open to suggestions!